### PR TITLE
i9300: use responseFailCause on REQUEST_LAST_CALL_FAIL_CAUSE

### DIFF
--- a/ril/telephony/java/com/android/internal/telephony/SamsungExynos4RIL.java
+++ b/ril/telephony/java/com/android/internal/telephony/SamsungExynos4RIL.java
@@ -186,7 +186,7 @@ public class SamsungExynos4RIL extends RIL implements CommandsInterface {
             case RIL_REQUEST_SWITCH_WAITING_OR_HOLDING_AND_ACTIVE: ret =  responseVoid(p); break;
             case RIL_REQUEST_CONFERENCE: ret =  responseVoid(p); break;
             case RIL_REQUEST_UDUB: ret =  responseVoid(p); break;
-            case RIL_REQUEST_LAST_CALL_FAIL_CAUSE: ret =  responseInts(p); break;
+            case RIL_REQUEST_LAST_CALL_FAIL_CAUSE: ret =  responseFailCause(p); break;
             case RIL_REQUEST_SIGNAL_STRENGTH: ret =  responseSignalStrength(p); break;
             case RIL_REQUEST_VOICE_REGISTRATION_STATE: ret =  responseStrings(p); break;
             case RIL_REQUEST_DATA_REGISTRATION_STATE: ret =  responseStrings(p); break;


### PR DESCRIPTION
fixes phone crashes when the call is disconnected from the other end

Change-Id: If6211af2d62ce9a6ee6879b67ae473b9fb9083d2
